### PR TITLE
Wordy words do word things.

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3124,8 +3124,7 @@ Defined in conflicts.dm of the #defines folder.
 			base_attachment_desc = "It has a [icon2html(src)] [name] for a stock."
 		if("under")
 			var/output = "It has a [icon2html(src)] [name]"
-			var/shorten = ""
-			shorten = in_chamber?.name
+			var/shorten = in_chamber?.name
 			var/list/select_text = splittext(shorten, " ")
 			if(length(select_text) > 1)
 				shorten = select_text?[1] + " " + select_text?[2]

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3124,9 +3124,13 @@ Defined in conflicts.dm of the #defines folder.
 			base_attachment_desc = "It has a [icon2html(src)] [name] for a stock."
 		if("under")
 			var/output = "It has a [icon2html(src)] [name]"
+			var/shorten = ""
+			shorten = in_chamber?.name
+			var/list/select_text = splittext(shorten, " ")
+			if(length(select_text) > 1)
+				shorten = select_text?[1] + " " + select_text?[2]
 			if(flags_attach_features & ATTACH_WEAPON)
-				output += " ([current_rounds]/[max_rounds]) [in_chamber ? "with an [in_chamber.name] chambered" : ""]"
-			output += " mounted underneath."
+				output += " ([current_rounds]/[max_rounds]) mounted underneath[in_chamber ? ", with an [shorten] chambered" : "."]"
 			base_attachment_desc = output
 		else
 			base_attachment_desc = "It has a [icon2html(src)] [name] attached."

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -3130,7 +3130,7 @@ Defined in conflicts.dm of the #defines folder.
 			if(length(select_text) > 1)
 				shorten = select_text?[1] + " " + select_text?[2]
 			if(flags_attach_features & ATTACH_WEAPON)
-				output += " ([current_rounds]/[max_rounds]) mounted underneath[in_chamber ? ", with an [shorten] chambered" : "."]"
+				output += " ([current_rounds]/[max_rounds]) mounted underneath[in_chamber ? ", with an [shorten] chambered." : "."]"
 			base_attachment_desc = output
 		else
 			base_attachment_desc = "It has a [icon2html(src)] [name] attached."


### PR DESCRIPTION

# About the pull request
Probably doesn't explode. Tested with some grenades and tested with nothing in the chamber.
Also why does the dumb UPP UGL not use in_chamber guh.

Uses the spaces to determine where to explode the wordy-ness into a billion pieces with the cunning use of splittext
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
/:cl:
